### PR TITLE
Add rule service along with its unit test

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,8 +18,8 @@
         "dev": "yarn db:migrate && yarn db:seed && nodemon server.js",
         "test": "mocha --reporter=mochawesome --reporter-options reportDir=./.reports/mocha ./tests/**/*.test.js",
         "ci:test": "nyc npm test",
-        "lint": "eslint --ext .js .",
-        "ci:lint": "mkdir -p ./reports && eslint --format=html --output-file ./.reports/eslint/eslint.html --max-warnings 10 --ext .js .",
+        "lint": "eslint --max-warnings 10 --ext .js .",
+        "ci:lint": "eslint --format=html --output-file ./.reports/eslint/eslint.html --max-warnings 10 --ext .js .",
         "ci:coverage": "nyc report --reporter=text-lcov | coveralls"
     },
     "pre-commit": [

--- a/server/services/rule.js
+++ b/server/services/rule.js
@@ -1,0 +1,79 @@
+const DB = require('../models');
+
+const { Rule } = DB;
+
+/**
+ * Create new rule
+ * @param {Object} queryObj
+ * @returns {Promise<Rule>}
+ */
+async function createRule(queryObj) {
+    const [rule, created] = await Rule.findOrCreate(queryObj, { default: queryObj });
+    if (!created) {
+        throw new Error('Duplicated Rule');
+    }
+
+    return rule;
+}
+
+/**
+ * Soft delete rule
+ * @param {Number} id
+ * @returns {Promise<void>}
+ */
+async function deleteRule(id) {
+    const count = await Rule.destroy(id);
+    if (count === 0) {
+        throw new Error('Rule not found');
+    }
+}
+
+/**
+ * Get rule with primary key from Database
+ * @param {Number} id
+ * @returns {Promise<Rule>}
+ */
+async function getRule(id) {
+    const rule = await Rule.findByPk(id);
+
+    if (!rule) {
+        throw new Error('Rule not found');
+    }
+
+    return rule;
+}
+
+/**
+ * Get rules from Database
+ * @returns {Promise<Array<Rule>>}
+ */
+async function getRules() {
+    const rules = await Rule.findAll();
+    return rules;
+}
+
+/**
+ * Update rule with id and updateObject
+ * @param {Number} id
+ * @param {Object} updateObj
+ */
+async function updateRule(id, updateObj) {
+    const [count, [rule]] = await Rule.update(updateObj, {
+        returning: true,
+        where: { id },
+    });
+
+    if (count === 0) {
+        throw new Error('Rule not found');
+    }
+
+    return rule;
+}
+
+module.exports = {
+    createRule,
+    deleteRule,
+    getRule,
+    getRules,
+    updateRule,
+};

--- a/server/tests/unit/services/rule.test.js
+++ b/server/tests/unit/services/rule.test.js
@@ -1,0 +1,151 @@
+const chai = require('chai');
+const faker = require('faker');
+const sinon = require('sinon');
+
+sinon.assert.expose(chai.assert, { prefix: '' });
+const { assert } = chai;
+
+const DB = require('../../../models');
+const modelFactory = require('../../factory');
+const ruleService = require('../../../services/rule');
+
+const { Rule } = DB;
+
+describe('service/rule', () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('createRule()', () => {
+        let rule;
+
+        const ruleObj = { coordinateX: faker.random.number(10), coordinateY: faker.random.number(10) };
+
+        beforeEach(() => {
+            rule = modelFactory(Rule, ruleObj);
+        });
+
+        it('should throw error duplicated rule', async () => {
+            sandbox.stub(Rule, 'findOrCreate')
+                .resolves([rule, false]);
+
+            try {
+                await ruleService.createRule(ruleObj);
+                assert.fail('it should fail but pass');
+            } catch (err) {
+                assert.equal(err.message, 'Duplicated Rule');
+            }
+        });
+
+        it('should create new rule', async () => {
+            sandbox.stub(Rule, 'findOrCreate')
+                .resolves([rule, true]);
+
+            const actual = await ruleService.createRule(ruleObj);
+            assert.equal(actual, rule);
+        });
+    });
+
+    describe('deleteRule()', () => {
+        it('should throw rule not found', async () => {
+            sandbox.stub(Rule, 'destroy')
+                .resolves(0);
+
+            try {
+                await ruleService.deleteRule(1);
+                assert.fail('it should fail but pass');
+            } catch (err) {
+                assert.equal(err.message, 'Rule not found');
+            }
+        });
+
+        it('should delete rule', async () => {
+            sandbox.stub(Rule, 'destroy')
+                .resolves(1);
+
+            await ruleService.deleteRule(1);
+            assert.called(Rule.destroy);
+        });
+    });
+
+    describe('getRule()', () => {
+        let rule;
+
+        beforeEach(() => {
+            rule = modelFactory(Rule, { id: 1 });
+        });
+
+        it('should throw rule not found', async () => {
+            sandbox.stub(Rule, 'findByPk')
+                .resolves(undefined);
+
+            try {
+                await ruleService.getRule(1);
+                assert.fail('it should fail but pass');
+            } catch (err) {
+                assert.equal(err.message, 'Rule not found');
+            }
+        });
+
+        it('should return rule', async () => {
+            sandbox.stub(Rule, 'findByPk')
+                .resolves(rule);
+
+            const actual = await ruleService.getRule(1);
+            assert.equal(actual, rule);
+        });
+    });
+
+    describe('getRules()', () => {
+        let rules;
+
+        beforeEach(() => {
+            rules = modelFactory(Rule, {}, {}, 4);
+        });
+
+        it('should return rules', async () => {
+            sandbox.stub(Rule, 'findAll')
+                .resolves(rules);
+
+            const actual = await ruleService.getRules();
+            assert.deepEqual(actual, rules);
+        });
+    });
+
+    describe('updateRule()', () => {
+        let rule;
+
+        const id = 1;
+        const ruleObj = { id, coordinateX: faker.random.arrayElement([10, 15, 20, 25, 30]), coordinateY: faker.random.arrayElement([10, 15, 20, 25, 30]) };
+
+        beforeEach(() => {
+            [rule] = modelFactory(Rule, ruleObj);
+        });
+
+        it('should throw rule not found', async () => {
+            sandbox.stub(Rule, 'update')
+                .resolves([0, []]);
+
+            try {
+                await ruleService.updateRule(id, ruleObj);
+                assert.fail('it should fail but pass');
+            } catch (err) {
+                assert.equal(err.message, 'Rule not found');
+            }
+        });
+
+        it('should update rule', async () => {
+            sandbox.stub(Rule, 'update')
+                .resolves([1, [rule]]);
+
+            const actual = await ruleService.updateRule(id, ruleObj);
+            assert.equal(actual, rule);
+        });
+    });
+});

--- a/server/tests/unit/services/rule.test.js
+++ b/server/tests/unit/services/rule.test.js
@@ -122,7 +122,11 @@ describe('service/rule', () => {
         let rule;
 
         const id = 1;
-        const ruleObj = { id, coordinateX: faker.random.arrayElement([10, 15, 20, 25, 30]), coordinateY: faker.random.arrayElement([10, 15, 20, 25, 30]) };
+        const ruleObj = {
+            id,
+            coordinateX: faker.random.arrayElement([10, 15, 20, 25, 30]),
+            coordinateY: faker.random.arrayElement([10, 15, 20, 25, 30]),
+        };
 
         beforeEach(() => {
             [rule] = modelFactory(Rule, ruleObj);


### PR DESCRIPTION
After creating model for `Rule`, it's time for us to create rule service to utilize that model. This PR consists of `ruleService` and unit for particular service.
- `createRule()`
- `deleteRule()`
- `getRule()`
- `getRules()`
- `updateRule()`